### PR TITLE
audioflinger: Fix audio for WifiDisplay

### DIFF
--- a/services/audioflinger/AudioFlinger.cpp
+++ b/services/audioflinger/AudioFlinger.cpp
@@ -1518,7 +1518,8 @@ sp<IAudioRecord> AudioFlinger::openRecord(
     }
 
     // check calling permissions
-    if (!recordingAllowed(opPackageName, tid, clientUid)) {
+    if (!isTrustedCallingUid(callingUid) &&
+                 !recordingAllowed(opPackageName, tid, callingUid)) {
         ALOGE("openRecord() permission denied: recording not allowed");
         lStatus = PERMISSION_DENIED;
         goto Exit;

--- a/services/audiopolicy/service/AudioPolicyInterfaceImpl.cpp
+++ b/services/audiopolicy/service/AudioPolicyInterfaceImpl.cpp
@@ -353,7 +353,7 @@ status_t AudioPolicyService::getInputForAttr(const audio_attributes_t *attr,
             case AudioPolicyInterface::API_INPUT_TELEPHONY_RX:
                 // FIXME: use the same permission as for remote submix for now.
             case AudioPolicyInterface::API_INPUT_MIX_CAPTURE:
-                if (!captureAudioOutputAllowed(pid, uid)) {
+                if (!isTrustedCallingUid(callingUid) && !captureAudioOutputAllowed(pid, uid)) {
                     ALOGE("getInputForAttr() permission denied: capture not allowed");
                     status = PERMISSION_DENIED;
                 }


### PR DESCRIPTION
AudioFlinger is not able to determine the correct
pid/tid for WifiDisplay and thus we do not pass checks
for CAPTURE_AUDIO_OUTPUT and RECORD_AUDIO permissions.

To fix audio for WifiDisplay, it should be safe to
always allow a trusted calling uid (AID_MEDIA which
has the same perms as AID_AUDIOSERVER).

Change-Id: Ifa46d8e77a43027645cad02a04263b58e134c3ad